### PR TITLE
Fix test script to use vitest run instead of watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "test": "vitest",
-    "test:run": "vitest run",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "tsc --noEmit",
     "clean": "rm -rf dist"
   },


### PR DESCRIPTION
## Summary
- Change `"test": "vitest"` (watch mode) to `"test": "vitest run"` (one-shot)
- Add `"test:watch": "vitest"` for interactive development use

`pnpm test` now exits cleanly after running instead of hanging in watch mode.

## Test plan
- [x] `pnpm test` exits with code 0 (29 tests pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined test command structure: the `test` command now directly executes tests without requiring a separate script.
  * Added `test:watch` command to enable watch mode for continuous testing during development, enhancing the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->